### PR TITLE
Add a sequence table function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- for benchmark -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-benchmark</artifactId>
+            <version>${dep.trino.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <air.check.fail-checkstyle>true</air.check.fail-checkstyle>
         <air.check.skip-checkstyle>false</air.check.skip-checkstyle>
 
-        <dep.trino.version>392</dep.trino.version>
-        <dep.airlift.version>217</dep.airlift.version>
+        <dep.trino.version>393</dep.trino.version>
+        <dep.airlift.version>218</dep.airlift.version>
         <dep.packaging.version>\${dep.airlift.version}</dep.packaging.version>
         <dep.errorprone.version>2.15.0</dep.errorprone.version>
         <dep.jackson.version>2.13.3</dep.jackson.version>
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.10.14</version>
+            <version>2.11.0</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/src/main/java/pl/net/was/FakerColumnHandle.java
+++ b/src/main/java/pl/net/was/FakerColumnHandle.java
@@ -30,6 +30,7 @@ public class FakerColumnHandle
     private final Type type;
     private final double nullProbability;
     private final String generator;
+    private final Long step;
 
     @JsonCreator
     public FakerColumnHandle(
@@ -37,13 +38,15 @@ public class FakerColumnHandle
             @JsonProperty("name") String name,
             @JsonProperty("type") Type type,
             @JsonProperty("nullProbability") double nullProbability,
-            @JsonProperty("generator") String generator)
+            @JsonProperty("generator") String generator,
+            @JsonProperty("step") Long step)
     {
         this.columnIndex = columnIndex;
         this.name = name;
         this.type = type;
         this.nullProbability = nullProbability;
         this.generator = generator;
+        this.step = step;
     }
 
     @JsonProperty("columnIndex")
@@ -74,6 +77,12 @@ public class FakerColumnHandle
     public Optional<String> getGenerator()
     {
         return Optional.ofNullable(generator);
+    }
+
+    @JsonProperty("step")
+    public Optional<Long> getStep()
+    {
+        return Optional.ofNullable(step);
     }
 
     @Override

--- a/src/main/java/pl/net/was/FakerConfig.java
+++ b/src/main/java/pl/net/was/FakerConfig.java
@@ -25,7 +25,7 @@ public class FakerConfig
 {
     private double nullProbability = 0.5;
     private long defaultLimit = 1000L;
-    private int minSplits = 4;
+    private int minSplits = 1;
 
     @NotNull
     @Max(1)

--- a/src/main/java/pl/net/was/FakerConnector.java
+++ b/src/main/java/pl/net/was/FakerConnector.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorCapabilities;
 import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -45,6 +46,7 @@ public class FakerConnector
     private final FakerMetadata metadata;
     private final FakerSplitManager splitManager;
     private final FakerRecordSetProvider recordSetProvider;
+    private final FakerPageSinkProvider pageSinkProvider;
 
     public static final String NULL_PROBABILITY_PROPERTY = "null_probability";
     public static final String DEFAULT_LIMIT_PROPERTY = "default_limit";
@@ -53,11 +55,13 @@ public class FakerConnector
     public FakerConnector(
             FakerMetadata metadata,
             FakerSplitManager splitManager,
-            FakerRecordSetProvider recordSetProvider)
+            FakerRecordSetProvider recordSetProvider,
+            FakerPageSinkProvider pageSinkProvider)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+        this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
     }
 
     @Override
@@ -82,6 +86,12 @@ public class FakerConnector
     public ConnectorRecordSetProvider getRecordSetProvider()
     {
         return recordSetProvider;
+    }
+
+    @Override
+    public ConnectorPageSinkProvider getPageSinkProvider()
+    {
+        return pageSinkProvider;
     }
 
     @Override

--- a/src/main/java/pl/net/was/FakerConnector.java
+++ b/src/main/java/pl/net/was/FakerConnector.java
@@ -15,6 +15,7 @@
 package pl.net.was;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorCapabilities;
 import io.trino.spi.connector.ConnectorMetadata;
@@ -22,6 +23,7 @@ import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 
@@ -135,5 +137,11 @@ public class FakerConnector
                         null,
                         recordSetProvider::validateGenerator,
                         false));
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return ImmutableSet.of(new SequenceFunction());
     }
 }

--- a/src/main/java/pl/net/was/FakerMetadata.java
+++ b/src/main/java/pl/net/was/FakerMetadata.java
@@ -36,8 +36,12 @@ import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.TableColumnsMetadata;
+import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.type.CharType;
@@ -64,6 +68,7 @@ import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.INVALID_COLUMN_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.connector.RetryMode.NO_RETRIES;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -139,7 +144,14 @@ public class FakerMetadata
             ConnectorTableHandle connectorTableHandle)
     {
         FakerTableHandle tableHandle = Types.checkType(connectorTableHandle, FakerTableHandle.class, "tableHandle");
-        return tables.get(tableHandle.getId()).getMetadata();
+        if (tableHandle.getId().isEmpty()) {
+            return new ConnectorTableMetadata(
+                    new SchemaTableName(SCHEMA_NAME, "seq"),
+                    List.of(new ColumnMetadata("seq", BIGINT)),
+                    Map.of(),
+                    Optional.empty());
+        }
+        return tables.get(tableHandle.getId().get()).getMetadata();
     }
 
     @Override
@@ -157,7 +169,7 @@ public class FakerMetadata
             ConnectorTableHandle connectorTableHandle)
     {
         FakerTableHandle tableHandle = Types.checkType(connectorTableHandle, FakerTableHandle.class, "tableHandle");
-        return tables.get(tableHandle.getId())
+        return tables.get(tableHandle.getId().get())
                 .getColumns().stream()
                 .collect(toImmutableMap(ColumnInfo::getName, ColumnInfo::getHandle));
     }
@@ -169,7 +181,10 @@ public class FakerMetadata
             ColumnHandle columnHandle)
     {
         FakerTableHandle tableHandle = Types.checkType(connectorTableHandle, FakerTableHandle.class, "tableHandle");
-        return tables.get(tableHandle.getId())
+        if (tableHandle.getId().isEmpty()) {
+            return new ColumnMetadata("seq", BIGINT);
+        }
+        return tables.get(tableHandle.getId().get())
                 .getColumn(columnHandle)
                 .getMetadata();
     }
@@ -189,7 +204,7 @@ public class FakerMetadata
     public synchronized void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         FakerTableHandle handle = (FakerTableHandle) tableHandle;
-        TableInfo info = tables.remove(handle.getId());
+        TableInfo info = tables.remove(handle.getId().get());
         if (info != null) {
             tableIds.remove(info.getSchemaTableName());
         }
@@ -202,7 +217,7 @@ public class FakerMetadata
         checkTableNotExists(newTableName);
 
         FakerTableHandle handle = (FakerTableHandle) tableHandle;
-        long tableId = handle.getId();
+        long tableId = handle.getId().get();
 
         TableInfo oldInfo = tables.get(tableId);
         tables.put(tableId, new TableInfo(
@@ -221,7 +236,7 @@ public class FakerMetadata
     public void setTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle, Map<String, Optional<Object>> properties)
     {
         FakerTableHandle handle = (FakerTableHandle) tableHandle;
-        long tableId = handle.getId();
+        long tableId = handle.getId().get();
 
         TableInfo oldInfo = tables.get(tableId);
         Map<String, Object> newProperties = Stream.concat(
@@ -237,7 +252,7 @@ public class FakerMetadata
     public void setTableComment(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> comment)
     {
         FakerTableHandle handle = (FakerTableHandle) tableHandle;
-        long tableId = handle.getId();
+        long tableId = handle.getId().get();
 
         TableInfo oldInfo = tables.get(tableId);
         tables.put(tableId, oldInfo.cloneWithComment(comment));
@@ -247,7 +262,7 @@ public class FakerMetadata
     public void setColumnComment(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column, Optional<String> comment)
     {
         FakerTableHandle handle = (FakerTableHandle) tableHandle;
-        long tableId = handle.getId();
+        long tableId = handle.getId().get();
 
         TableInfo oldInfo = tables.get(tableId);
         List<ColumnInfo> columns = oldInfo.getColumns().stream()
@@ -290,7 +305,13 @@ public class FakerMetadata
                 nullProbability = (double) column.getProperties().getOrDefault(ColumnInfo.NULL_PROBABILITY_PROPERTY, tableNullProbability);
             }
             columns.add(new ColumnInfo(
-                    new FakerColumnHandle(i, column.getName(), column.getType(), nullProbability, (String) column.getProperties().get(ColumnInfo.GENERATOR_PROPERTY)),
+                    new FakerColumnHandle(
+                            i,
+                            column.getName(),
+                            column.getType(),
+                            nullProbability,
+                            (String) column.getProperties().get(ColumnInfo.GENERATOR_PROPERTY),
+                            null),
                     column));
         }
 
@@ -423,5 +444,25 @@ public class FakerMetadata
                 fakerTable.cloneWithConstraint(currentConstraint),
                 TupleDomain.all(),
                 true));
+    }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(ConnectorSession session, ConnectorTableFunctionHandle handle)
+    {
+        if (!(handle instanceof SequenceTableHandle generatorHandle)) {
+            return Optional.empty();
+        }
+        // TODO adjust limit and step to `config.getMinSplits()`
+        long limit = 1 + (generatorHandle.getStop() - generatorHandle.getStart()) / generatorHandle.getStep();
+        FakerColumnHandle column = new FakerColumnHandle(0, "seq", BIGINT, 0, "", generatorHandle.getStep());
+        TupleDomain<ColumnHandle> constraint = TupleDomain.withColumnDomains(Map.of(
+                column, Domain.create(ValueSet.ofRanges(Range.range(
+                        BIGINT,
+                        generatorHandle.getStart(),
+                        true,
+                        generatorHandle.getStop(),
+                        true)), false)));
+        FakerTableHandle tableHandle = new FakerTableHandle(null, new SchemaTableName(SCHEMA_NAME, "generator"), constraint, limit);
+        return Optional.of(new TableFunctionApplicationResult<>(tableHandle, List.of(column)));
     }
 }

--- a/src/main/java/pl/net/was/FakerModule.java
+++ b/src/main/java/pl/net/was/FakerModule.java
@@ -45,6 +45,7 @@ public class FakerModule
         binder.bind(FakerMetadata.class).in(Scopes.SINGLETON);
         binder.bind(FakerSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(FakerRecordSetProvider.class).in(Scopes.SINGLETON);
+        binder.bind(FakerPageSinkProvider.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(FakerConfig.class);
     }
 }

--- a/src/main/java/pl/net/was/FakerPageSinkProvider.java
+++ b/src/main/java/pl/net/was/FakerPageSinkProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.net.was;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSinkProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+
+import javax.inject.Inject;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class FakerPageSinkProvider
+        implements ConnectorPageSinkProvider
+{
+    @Inject
+    public FakerPageSinkProvider()
+    {
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle)
+    {
+        return new PageSink();
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle)
+    {
+        return new PageSink();
+    }
+
+    private static class PageSink
+            implements ConnectorPageSink
+    {
+        @Override
+        public CompletableFuture<?> appendPage(Page page)
+        {
+            throw new UnsupportedOperationException("The faker connector does not support writes");
+        }
+
+        @Override
+        public CompletableFuture<Collection<Slice>> finish()
+        {
+            return completedFuture(ImmutableList.of());
+        }
+
+        @Override
+        public void abort()
+        {
+            throw new UnsupportedOperationException("The faker connector does not support writes");
+        }
+    }
+}

--- a/src/main/java/pl/net/was/FakerSplit.java
+++ b/src/main/java/pl/net/was/FakerSplit.java
@@ -21,14 +21,14 @@ import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
 
-public class FakerConnectorSplit
+public class FakerSplit
         implements ConnectorSplit
 {
     private final FakerTableHandle tableHandle;
     private final List<HostAddress> addresses;
 
     @JsonCreator
-    public FakerConnectorSplit(
+    public FakerSplit(
             @JsonProperty("tableHandle") FakerTableHandle tableHandle,
             @JsonProperty("addresses") List<HostAddress> addresses)
     {

--- a/src/main/java/pl/net/was/FakerSplitManager.java
+++ b/src/main/java/pl/net/was/FakerSplitManager.java
@@ -53,9 +53,9 @@ public class FakerSplitManager
             Constraint constraint)
     {
         FakerTableHandle fakerTable = (FakerTableHandle) table;
-        List<FakerConnectorSplit> splits = nodeManager.getRequiredWorkerNodes().stream()
+        List<FakerSplit> splits = nodeManager.getRequiredWorkerNodes().stream()
                 .flatMap(node -> Stream.generate(
-                                () -> new FakerConnectorSplit(fakerTable, List.of(node.getHostAndPort())))
+                                () -> new FakerSplit(fakerTable, List.of(node.getHostAndPort())))
                         .limit(fakerTable.getId().isPresent() ? config.getMinSplits() : 1))
                 .collect(toList());
 

--- a/src/main/java/pl/net/was/FakerSplitManager.java
+++ b/src/main/java/pl/net/was/FakerSplitManager.java
@@ -52,10 +52,11 @@ public class FakerSplitManager
             DynamicFilter dynamicFilter,
             Constraint constraint)
     {
+        FakerTableHandle fakerTable = (FakerTableHandle) table;
         List<FakerConnectorSplit> splits = nodeManager.getRequiredWorkerNodes().stream()
                 .flatMap(node -> Stream.generate(
-                                () -> new FakerConnectorSplit((FakerTableHandle) table, List.of(node.getHostAndPort())))
-                        .limit(config.getMinSplits()))
+                                () -> new FakerConnectorSplit(fakerTable, List.of(node.getHostAndPort())))
+                        .limit(fakerTable.getId().isPresent() ? config.getMinSplits() : 1))
                 .collect(toList());
 
         return new FixedSplitSource(splits);

--- a/src/main/java/pl/net/was/FakerTableHandle.java
+++ b/src/main/java/pl/net/was/FakerTableHandle.java
@@ -22,18 +22,19 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.Objects;
+import java.util.Optional;
 
 public class FakerTableHandle
         implements ConnectorTableHandle, Cloneable
 {
-    private final long id;
+    private final Long id;
     private final SchemaTableName schemaTableName;
     private TupleDomain<ColumnHandle> constraint;
     private long limit;
 
     @JsonCreator
     public FakerTableHandle(
-            @JsonProperty("id") long id,
+            @JsonProperty("id") Long id,
             @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
             @JsonProperty("limit") long limit)
@@ -45,9 +46,9 @@ public class FakerTableHandle
     }
 
     @JsonProperty
-    public long getId()
+    public Optional<Long> getId()
     {
-        return id;
+        return Optional.ofNullable(id);
     }
 
     @JsonProperty("schemaTableName")
@@ -79,13 +80,15 @@ public class FakerTableHandle
         }
         FakerTableHandle that = (FakerTableHandle) o;
         return id == that.id &&
-                schemaTableName.equals(that.schemaTableName);
+                schemaTableName.equals(that.schemaTableName) &&
+                constraint.equals(that.constraint) &&
+                limit == that.limit;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(id, schemaTableName);
+        return Objects.hash(id, schemaTableName, constraint, limit);
     }
 
     public String toString()

--- a/src/main/java/pl/net/was/SequenceFunction.java
+++ b/src/main/java/pl/net/was/SequenceFunction.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.net.was;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.ptf.AbstractConnectorTableFunction;
+import io.trino.spi.ptf.Argument;
+import io.trino.spi.ptf.Descriptor;
+import io.trino.spi.ptf.ScalarArgument;
+import io.trino.spi.ptf.ScalarArgumentSpecification;
+import io.trino.spi.ptf.TableFunctionAnalysis;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.ptf.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static java.util.stream.Collectors.toList;
+
+public class SequenceFunction
+        extends AbstractConnectorTableFunction
+{
+    public SequenceFunction()
+    {
+        super(
+                "default",
+                "sequence",
+                List.of(
+                        ScalarArgumentSpecification.builder()
+                                .name("START")
+                                .type(BIGINT)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name("STOP")
+                                .type(BIGINT)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name("STEP")
+                                .type(BIGINT)
+                                .defaultValue(1L)
+                                .build()),
+                GENERIC_TABLE);
+    }
+
+    @Override
+    public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)
+    {
+        long start = (long) ((ScalarArgument) arguments.get("START")).getValue();
+        long stop = (long) ((ScalarArgument) arguments.get("STOP")).getValue();
+        long step = (long) ((ScalarArgument) arguments.get("STEP")).getValue();
+
+        if (start < 1) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "start must be positive");
+        }
+        if (stop < 1) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "stop must be positive");
+        }
+        if (step < 1) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "step must be positive");
+        }
+
+        // determine the returned row type
+        List<Descriptor.Field> fields = Stream.of("seq")
+                .map(name -> new Descriptor.Field(name, Optional.of(BIGINT)))
+                .collect(toList());
+
+        Descriptor returnedType = new Descriptor(fields);
+
+        return TableFunctionAnalysis.builder()
+                .returnedType(returnedType)
+                .handle(new SequenceTableHandle(start, stop, step))
+                .build();
+    }
+}

--- a/src/main/java/pl/net/was/SequenceTableHandle.java
+++ b/src/main/java/pl/net/was/SequenceTableHandle.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.net.was;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.ptf.ConnectorTableFunctionHandle;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public class SequenceTableHandle
+        implements ConnectorTableFunctionHandle
+{
+    private final long start;
+    private final long stop;
+    private final long step;
+
+    @JsonCreator
+    public SequenceTableHandle(
+            @JsonProperty("start") long start,
+            @JsonProperty("stop") long stop,
+            @JsonProperty("step") long step)
+    {
+        this.start = start;
+        this.stop = stop;
+        this.step = step;
+    }
+
+    @JsonProperty
+    public long getStart()
+    {
+        return start;
+    }
+
+    @JsonProperty
+    public long getStop()
+    {
+        return stop;
+    }
+
+    @JsonProperty
+    public long getStep()
+    {
+        return step;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SequenceTableHandle that = (SequenceTableHandle) o;
+        return start == that.start && stop == that.stop && step == that.step;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(start, stop, step);
+    }
+
+    public String toString()
+    {
+        return format("Sequence(%d, %d, %d)", start, stop, step);
+    }
+}

--- a/src/test/java/pl/net/was/BenchmarkQueryRunner.java
+++ b/src/test/java/pl/net/was/BenchmarkQueryRunner.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.net.was;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.testing.LocalQueryRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
+
+public final class BenchmarkQueryRunner
+{
+    private BenchmarkQueryRunner() {}
+
+    public static LocalQueryRunner createLocalQueryRunner(File tempDir)
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("faker")
+                .setSchema("default")
+                .build();
+
+        LocalQueryRunner localQueryRunner = LocalQueryRunner.create(session);
+
+        localQueryRunner.createCatalog("tpch", new TpchConnectorFactory(1), ImmutableMap.of());
+
+        localQueryRunner.installPlugin(new FakerPlugin());
+
+        localQueryRunner.createCatalog(
+                "faker",
+                "faker",
+                Map.of());
+
+        localQueryRunner.execute("CREATE TABLE orders AS SELECT * FROM tpch.sf1.orders WITH NO DATA");
+        localQueryRunner.execute("CREATE TABLE lineitem AS SELECT * FROM tpch.sf1.lineitem WITH NO DATA");
+        return localQueryRunner;
+    }
+
+    public static void main(String[] args)
+            throws IOException
+    {
+        String outputDirectory = requireNonNull(System.getProperty("outputDirectory"), "Must specify -DoutputDirectory=...");
+        File tempDir = Files.createTempDirectory(null).toFile();
+        try (LocalQueryRunner localQueryRunner = createLocalQueryRunner(tempDir)) {
+            new FakerBenchmarkSuite(localQueryRunner, outputDirectory).runAllBenchmarks();
+        }
+        finally {
+            deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+        }
+    }
+}

--- a/src/test/java/pl/net/was/FakerBenchmarkSuite.java
+++ b/src/test/java/pl/net/was/FakerBenchmarkSuite.java
@@ -26,7 +26,9 @@ import io.trino.benchmark.OdsBenchmarkResultWriter;
 import io.trino.benchmark.SimpleLineBenchmarkResultWriter;
 import io.trino.testing.LocalQueryRunner;
 import pl.net.was.benchmark.BaselineRandomPrimitiveType;
+import pl.net.was.benchmark.BaselineSequence;
 import pl.net.was.benchmark.RandomPrimitiveType;
+import pl.net.was.benchmark.TableFuncSequence;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -55,7 +57,9 @@ public class FakerBenchmarkSuite
     {
         return ImmutableList.of(
                 new BaselineRandomPrimitiveType(localQueryRunner),
-                new RandomPrimitiveType(localQueryRunner));
+                new RandomPrimitiveType(localQueryRunner),
+                new BaselineSequence(localQueryRunner),
+                new TableFuncSequence(localQueryRunner));
     }
 
     public void runAllBenchmarks()

--- a/src/test/java/pl/net/was/FakerBenchmarkSuite.java
+++ b/src/test/java/pl/net/was/FakerBenchmarkSuite.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.net.was;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
+import io.airlift.log.Logger;
+import io.trino.benchmark.AbstractBenchmark;
+import io.trino.benchmark.BenchmarkResultHook;
+import io.trino.benchmark.BenchmarkSuite;
+import io.trino.benchmark.JsonAvgBenchmarkResultWriter;
+import io.trino.benchmark.JsonBenchmarkResultWriter;
+import io.trino.benchmark.OdsBenchmarkResultWriter;
+import io.trino.benchmark.SimpleLineBenchmarkResultWriter;
+import io.trino.testing.LocalQueryRunner;
+import pl.net.was.benchmark.BaselineRandomPrimitiveType;
+import pl.net.was.benchmark.RandomPrimitiveType;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class FakerBenchmarkSuite
+{
+    private static final Logger LOGGER = Logger.get(BenchmarkSuite.class);
+
+    private final LocalQueryRunner localQueryRunner;
+    private final String outputDirectory;
+
+    public FakerBenchmarkSuite(LocalQueryRunner localQueryRunner, String outputDirectory)
+    {
+        this.localQueryRunner = localQueryRunner;
+        this.outputDirectory = outputDirectory;
+    }
+
+    public static List<AbstractBenchmark> createBenchmarks(LocalQueryRunner localQueryRunner)
+    {
+        return ImmutableList.of(
+                new BaselineRandomPrimitiveType(localQueryRunner),
+                new RandomPrimitiveType(localQueryRunner));
+    }
+
+    public void runAllBenchmarks()
+            throws IOException
+    {
+        List<AbstractBenchmark> benchmarks = createBenchmarks(localQueryRunner);
+
+        LOGGER.info("=== Pre-running all benchmarks for JVM warmup ===");
+        for (AbstractBenchmark benchmark : benchmarks) {
+            benchmark.runBenchmark();
+        }
+
+        LOGGER.info("=== Actually running benchmarks for metrics ===");
+        for (AbstractBenchmark benchmark : benchmarks) {
+            try (OutputStream jsonOut = new FileOutputStream(createOutputFile(format("%s/json/%s.json", outputDirectory, benchmark.getBenchmarkName())));
+                    OutputStream jsonAvgOut = new FileOutputStream(createOutputFile(format("%s/json-avg/%s.json", outputDirectory, benchmark.getBenchmarkName())));
+                    OutputStream csvOut = new FileOutputStream(createOutputFile(format("%s/csv/%s.csv", outputDirectory, benchmark.getBenchmarkName())));
+                    OutputStream odsOut = new FileOutputStream(createOutputFile(format("%s/ods/%s.json", outputDirectory, benchmark.getBenchmarkName())))) {
+                benchmark.runBenchmark(
+                        new ForwardingBenchmarkResultWriter(
+                                ImmutableList.of(
+                                        new JsonBenchmarkResultWriter(jsonOut),
+                                        new JsonAvgBenchmarkResultWriter(jsonAvgOut),
+                                        new SimpleLineBenchmarkResultWriter(csvOut),
+                                        new OdsBenchmarkResultWriter("trino.benchmark." + benchmark.getBenchmarkName(), odsOut))));
+            }
+        }
+    }
+
+    private static File createOutputFile(String fileName)
+            throws IOException
+    {
+        File outputFile = new File(fileName);
+        Files.createParentDirs(outputFile);
+        return outputFile;
+    }
+
+    private static class ForwardingBenchmarkResultWriter
+            implements BenchmarkResultHook
+    {
+        private final List<BenchmarkResultHook> benchmarkResultHooks;
+
+        private ForwardingBenchmarkResultWriter(List<BenchmarkResultHook> benchmarkResultHooks)
+        {
+            requireNonNull(benchmarkResultHooks, "benchmarkResultHooks is null");
+            this.benchmarkResultHooks = ImmutableList.copyOf(benchmarkResultHooks);
+        }
+
+        @Override
+        public BenchmarkResultHook addResults(Map<String, Long> results)
+        {
+            requireNonNull(results, "results is null");
+            for (BenchmarkResultHook benchmarkResultHook : benchmarkResultHooks) {
+                benchmarkResultHook.addResults(results);
+            }
+            return this;
+        }
+
+        @Override
+        public void finished()
+        {
+            for (BenchmarkResultHook benchmarkResultHook : benchmarkResultHooks) {
+                benchmarkResultHook.finished();
+            }
+        }
+    }
+}

--- a/src/test/java/pl/net/was/TestFakerQueries.java
+++ b/src/test/java/pl/net/was/TestFakerQueries.java
@@ -599,4 +599,12 @@ public class TestFakerQueries
 
         assertUpdate("DROP TABLE faker.default.all_types_range");
     }
+
+    @Test
+    public void selectSeq()
+    {
+        @Language("SQL")
+        String testQuery = "SELECT seq FROM TABLE(faker.default.sequence(start => 10, stop => 20, step => 3))";
+        assertQuery(testQuery, "VALUES (10), (13), (16), (19)");
+    }
 }

--- a/src/test/java/pl/net/was/benchmark/BaselineRandomPrimitiveType.java
+++ b/src/test/java/pl/net/was/benchmark/BaselineRandomPrimitiveType.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.net.was.benchmark;
+
+import io.trino.benchmark.AbstractSqlBenchmark;
+import io.trino.testing.LocalQueryRunner;
+
+public class BaselineRandomPrimitiveType
+        extends AbstractSqlBenchmark
+{
+    public BaselineRandomPrimitiveType(LocalQueryRunner localQueryRunner)
+    {
+        super(localQueryRunner, "baseline_primitive_type", 2, 5, "SELECT count(*) FROM (SELECT * FROM tpch.sf10.orders)");
+    }
+
+    @Override
+    protected void tearDown()
+    {
+        // Default: no-op
+    }
+}

--- a/src/test/java/pl/net/was/benchmark/BaselineSequence.java
+++ b/src/test/java/pl/net/was/benchmark/BaselineSequence.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.net.was.benchmark;
+
+import io.trino.benchmark.AbstractSqlBenchmark;
+import io.trino.testing.LocalQueryRunner;
+
+public class BaselineSequence
+        extends AbstractSqlBenchmark
+{
+    public BaselineSequence(LocalQueryRunner localQueryRunner)
+    {
+        super(localQueryRunner, "baseline_sequence", 2, 5, """
+                SELECT count(*) FROM (SELECT * FROM unnest(sequence(1,10000)) a CROSS JOIN unnest(sequence(1,10000)) b)""");
+    }
+
+    @Override
+    protected void tearDown()
+    {
+        // Default: no-op
+    }
+}

--- a/src/test/java/pl/net/was/benchmark/RandomPrimitiveType.java
+++ b/src/test/java/pl/net/was/benchmark/RandomPrimitiveType.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.net.was.benchmark;
+
+import io.trino.benchmark.AbstractSqlBenchmark;
+import io.trino.testing.LocalQueryRunner;
+
+public class RandomPrimitiveType
+        extends AbstractSqlBenchmark
+{
+    public RandomPrimitiveType(LocalQueryRunner localQueryRunner)
+    {
+        super(localQueryRunner, "random_primitive_type", 2, 5, "SELECT count(*) FROM (SELECT * FROM orders LIMIT 15000000)");
+    }
+
+    @Override
+    protected void tearDown()
+    {
+        // Default: no-op
+    }
+}

--- a/src/test/java/pl/net/was/benchmark/TableFuncSequence.java
+++ b/src/test/java/pl/net/was/benchmark/TableFuncSequence.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.net.was.benchmark;
+
+import io.trino.benchmark.AbstractSqlBenchmark;
+import io.trino.testing.LocalQueryRunner;
+
+public class TableFuncSequence
+        extends AbstractSqlBenchmark
+{
+    public TableFuncSequence(LocalQueryRunner localQueryRunner)
+    {
+        super(localQueryRunner, "table_func_sequence", 2, 5, """
+                SELECT count(*) FROM (SELECT * FROM TABLE(faker.default.sequence(1,100000000)))""");
+    }
+
+    @Override
+    protected void tearDown()
+    {
+        // Default: no-op
+    }
+}


### PR DESCRIPTION
It behaves exactly as the built-in `sequence(start, stop, step)` but:
* does not have a limit on the number of generated rows
* does not handle date and timestamp types